### PR TITLE
Load all issues and PRs from all repos

### DIFF
--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -26,9 +26,14 @@ def is_same_issue(l, r):
 
 
 def _make_issue(repo, gh_data):
+    if gh_data["author"] is None:
+        # https://github.com/ghost
+        author = "ghost"
+    else:
+        author = gh_data["author"]["login"]
     return Issue(
         repo=repo,
-        author=gh_data["author"]["login"],
+        author=author,
         created_at=datetime.fromisoformat(gh_data["createdAt"]),
         updated_at=datetime.fromisoformat(gh_data["updatedAt"]),
         number=int(gh_data["number"]),
@@ -36,6 +41,34 @@ def _make_issue(repo, gh_data):
         url=gh_data["url"],
         is_read=bool(gh_data["isReadByViewer"]),
     )
+
+
+FRAGMENT_ISSUE = """
+fragment issueFields on Issue {
+    author {
+        login
+    }
+    createdAt
+    number
+    title
+    updatedAt
+    url
+    isReadByViewer
+}
+"""
+FRAGMENT_PR = """
+fragment prFields on PullRequest {
+    author {
+        login
+    }
+    createdAt
+    number
+    title
+    updatedAt
+    url
+    isReadByViewer
+}
+"""
 
 
 class IssueLoader:
@@ -52,7 +85,7 @@ class IssueLoader:
         self._lock = threading.Lock()
         self._logger = logging.getLogger("IssueLoader")
         self._executor = ThreadPoolExecutor(max_workers=1)
-        self._submit(self._load_initial_issues, repos, progress_callback)
+        self._submit(self._load_all_issues, repos, progress_callback)
 
     def _submit(self, *args):
         f = self._executor.submit(*args)
@@ -64,62 +97,161 @@ class IssueLoader:
         except:
             self._logger.exception("Exception in IssueLoader background thread")
 
-    def _load_initial_issues(self, repos, progress_callback):
+    def _load_all_issues(self, repos, progress_callback=None):
         num_repos_at_start = len(repos)
-        REPOS_PER_QUERY = 20
-        while repos:
-            repo_query = """
-            r%d: repository(owner: "%s", name: "%s") {
-                issues(first: 5, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
-                    nodes {
-                        author {
-                            login
-                        }
-                        createdAt
-                        number
-                        title
-                        updatedAt
-                        url
-                        isReadByViewer
-                    }
-                }
-                pullRequests(first: 5, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
-                    nodes {
-                        author {
-                            login
-                        }
-                        createdAt
-                        updatedAt
-                        number
-                        title
-                        url
-                        isReadByViewer
-                    }
-                }
-            }"""
-            repo_queries = []
-            for i, r in enumerate(repos[:REPOS_PER_QUERY]):
-                repo_queries.append(repo_query % (i, r.owner, r.name))
-            query = gql(
-                f"""
-                query {{
-                    {'\n'.join(repo_queries)}
-                }}
-                """
-            )
-            result = self._client.execute(query)
-            for i, r in enumerate(repos[:REPOS_PER_QUERY]):
-                rkey = f"r{i}"
-                data = result[rkey]
-                with self._lock:
-                    for issue in data["issues"]["nodes"]:
-                        self._upcomming_issues.append(_make_issue(r, issue))
-                    for pr in data["pullRequests"]["nodes"]:
-                        self._upcomming_issues.append(_make_issue(r, pr))
-            repos = repos[REPOS_PER_QUERY:]
-            self._upcomming_issues.sort(reverse=True, key=lambda i: i.updated_at)
-            progress_callback((num_repos_at_start - len(repos)) / num_repos_at_start)
+        # Make a copy to not modify caller
+        repos = list(repos)
 
+        REPOS_PER_QUERY = 10
+
+        # These dicts indicate if repos have more issues or PRs to query
+        issue_page_info = {}
+        pr_page_info = {}
+        for r in repos:
+            # Use "None" to mean we haven't queried anything yet
+            issue_page_info[r] = None
+            pr_page_info[r] = None
+
+        next_repo_queries = []
+        while issue_page_info or pr_page_info:
+            for r in repos:
+                issue_query = None
+                pr_query = None
+                if r in issue_page_info:
+                    ipi = issue_page_info[r]
+                    if ipi is None:
+                        # Initial query has no page info
+                        issue_query = """
+                        issues(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
+                            nodes {
+                                ...issueFields
+                            }
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                        }
+                        """
+                    elif ipi["hasNextPage"]:
+                        # Continuing query starts from previous page
+                        issue_query = (
+                            """
+                        issues(first: 100, after: "%s" orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
+                            nodes {
+                                ...issueFields
+                            }
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                        }
+                        """
+                            % ipi["endCursor"]
+                        )
+                if r in pr_page_info:
+                    prpi = pr_page_info[r]
+                    if prpi is None:
+                        # Initial query has no page info
+                        pr_query = """
+                        pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
+                                nodes {
+                                    ...prFields
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        """
+                    elif prpi["hasNextPage"]:
+                        # Continuqing query starts from previous page
+                        pr_query = (
+                            """
+                        pullRequests(first: 100, after: "%s" orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
+                                nodes {
+                                    ...prFields
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        """
+                            % prpi["endCursor"]
+                        )
+
+                if issue_query or pr_query:
+                    repo_query = (
+                        f'r{id(r)}: repository(owner: "{r.owner}", name: "{r.name}")'
+                    )
+                    repo_query += "{"
+                    if issue_query:
+                        repo_query += issue_query
+                    if pr_query:
+                        repo_query += pr_query
+                    repo_query += "}"
+                    next_repo_queries.append(repo_query)
+
+                if len(next_repo_queries) == REPOS_PER_QUERY or r == repos[-1]:
+                    query_str = f"""
+                        query {{
+                            {'\n'.join(next_repo_queries)}
+                        }}
+                        """
+                    # It's an error to include unused fragments
+                    if issue_page_info:
+                        query_str += FRAGMENT_ISSUE
+                    if pr_page_info:
+                        query_str += FRAGMENT_PR
+                    query = gql(query_str)
+                    next_repo_queries = []
+                    result = self._client.execute(query)
+                    for rr in repos:
+                        key = f"r{id(rr)}"
+                        if key in result:
+                            repo_result = result[key]
+                            if "issues" in repo_result:
+                                for issue in repo_result["issues"]["nodes"]:
+                                    self._upcomming_issues.append(
+                                        _make_issue(rr, issue)
+                                    )
+                                if repo_result["issues"]["pageInfo"]["hasNextPage"]:
+                                    issue_page_info[rr] = repo_result["issues"][
+                                        "pageInfo"
+                                    ]
+                                else:
+                                    del issue_page_info[rr]
+                            if "pullRequests" in repo_result:
+                                for pr in repo_result["pullRequests"]["nodes"]:
+                                    self._upcomming_issues.append(
+                                        _make_issue(rr, issue)
+                                    )
+                                if repo_result["pullRequests"]["pageInfo"][
+                                    "hasNextPage"
+                                ]:
+                                    pr_page_info[rr] = repo_result["pullRequests"][
+                                        "pageInfo"
+                                    ]
+                                else:
+                                    del pr_page_info[rr]
+                    if progress_callback:
+                        issue_max = num_repos_at_start
+                        pr_max = num_repos_at_start
+                        progress_callback(
+                            (
+                                issue_max
+                                - len(issue_page_info)
+                                + pr_max
+                                - len(pr_page_info)
+                            )
+                            / (issue_max + pr_max + 1)
+                        )
+            self._upcomming_issues.sort(reverse=True, key=lambda i: i.updated_at)
+            if progress_callback:
+                self._logger.info(
+                    f"Loaded {len(self._upcomming_issues)} issues and PRs"
+                )
+                progress_callback(1)
         # TODO submit work to regularly check for new issues
         pass
 

--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -206,7 +206,7 @@ class IssueLoader:
                 """
             next_queries = []
             # It's an error to include unused fragments,
-            # so  include only used ones
+            # so only include a fragment if it's used.
             if issue_page_info:
                 query_str += FRAGMENT_ISSUE
             if pr_page_info:
@@ -214,8 +214,8 @@ class IssueLoader:
             query = gql(query_str)
             result = self._client.execute(query)
 
-            # Figure out what repos we included in the query
-            # And for each one we did, add the issues and PRs to the upcomming list
+            # Figure out what repos the query included,
+            # and add the issues and PRs to the upcomming list
             for r in repos:
                 key = f"r{id(r)}"
                 if key not in result:
@@ -238,8 +238,10 @@ class IssueLoader:
                         del pr_page_info[r]
             if progress_callback:
                 i_max = pr_max = num_repos_at_start
-                # Add 1 in denominator so we only return 1 after
+                # Add 1 in denominator so 1 is only returned
                 # upcomming issues are sorted.
+                # This keeps the UI from advancing too quickly and
+                # displaying not-the-latest stuff.
                 progress_callback(
                     (i_max - len(issue_page_info) + pr_max - len(pr_page_info))
                     / (i_max + pr_max + 1)

--- a/src/treadi/repo_loader.py
+++ b/src/treadi/repo_loader.py
@@ -6,7 +6,7 @@ import time
 from gql import gql
 
 
-@dataclass
+@dataclass(frozen=True)
 class Repository:
     owner: str = ""
     name: str = ""


### PR DESCRIPTION
This makes TreadI load all issues and pull requests from all repos, instead of just the most recently updated 5 from each. This allows viewing all the issues if one clicks dismiss enough.