### PR TITLE
Fix issue height on high DPI screens

### DIFF
--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -107,7 +107,9 @@ class IssueScreen(Screen):
         # Add a new issue below the others (probably displaying below the bottom of the screen)
         self.add_next_issue(App.get_running_app().issue_loader)
         # Animate the dismissed widget shrinking
-        anim = Animation(height=0, opacity=0, duration=0.125, transition="out_cubic")
+        anim = Animation(
+            size_hint_y=0, opacity=0, duration=0.125, transition="out_cubic"
+        )
         anim.bind(on_complete=lambda *args: self.ids.stack.remove_widget(issue_widget))
         anim.start(issue_widget)
 

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -10,8 +10,7 @@
             size: self.size
 
     orientation: "horizontal"
-    size_hint_y: None
-    size_y: '100dp'
+    size_hint_y: 0.2
     BoxLayout:
         size_hint_x: 0.9
         orientation: "vertical"


### PR DESCRIPTION
This fixes the display height of issues on high DPI screens by using size_hint_y instead of trying to set the height in display pixels.