### PR TITLE
Avoid backslash inside of f-string

### DIFF
--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -199,9 +199,10 @@ class IssueLoader:
                     break
 
             # Execute the next query
+            joined_queries = "\n".join(next_queries)
             query_str = f"""
                 query {{
-                    {'\n'.join(next_queries)}
+                    {joined_queries}
                 }}
                 """
             next_queries = []


### PR DESCRIPTION
This is not supported on some python versions
https://stackoverflow.com/questions/67680296/syntaxerror-f-string-expression-part-cannot-include-a-backslash