### PR TITLE
Add back button

### DIFF
--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -11,7 +11,7 @@ Config.set("graphics", "resizable", False)
 Config.set("input", "mouse", "mouse,disable_multitouch")
 from kivy.core.window import Window
 
-Window.size = (500, 518)
+Window.size = (500, 571)
 from kivy.properties import ColorProperty
 from kivy.properties import NumericProperty
 from kivy.properties import ObjectProperty
@@ -93,6 +93,7 @@ class IssueWidget(ButtonBehavior, BoxLayout):
 class IssueScreen(Screen):
 
     def on_pre_enter(self):
+        print(self.manager.screens)
         issue_loader = App.get_running_app().issue_loader
         for i in range(5):
             self.add_next_issue(issue_loader)
@@ -113,7 +114,7 @@ class IssueScreen(Screen):
         )
         anim.bind(on_complete=lambda *args: self.ids.stack.remove_widget(issue_widget))
         anim.start(issue_widget)
-
+        
 
 class RepoPickerScreen(Screen):
 

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -10,7 +10,7 @@
             size: self.size
 
     orientation: "horizontal"
-    size_hint_y: 0.2
+    size_hint_y: 0.18
     BoxLayout:
         size_hint_x: 0.9
         orientation: "vertical"
@@ -96,6 +96,16 @@
         orientation: "tb-lr"
         padding: '3dp'
         spacing: '3dp'
+        BoxLayout:
+            orientation: "horizontal"
+            size_hint_y: 0.1
+            Button:
+                size_hint_x: 0.1
+                text: "back"
+                on_release:
+                    root.manager.transition.direction = "right"
+                    root.manager.current = "repos"
+                
 
 
 <RepoPickerScreen>:


### PR DESCRIPTION
Fixes #15 


This doesn't work because the repos screen disappears from the screen manager. I wonder if switch_to is clearing the repos list?

Regardless. I don't like the look of the back button. It changes how the UI feels, like there's one more decision to make at the top. If I do come back and implement this it might be with a keyboard shortcut instead (`Esc` to go back)