### PR TITLE
feature: Filter issues with github search like syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "gql[requests]>=3.5.0",
     "keyring>=25.6.0",
     "kivy>=2.3.1",
-    "lark[interegular]>=1.2.2",
     "python-dateutil>=2.8.0",
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
@@ -51,6 +50,7 @@ line-length = 88
 dev = [
     "black>=25.1.0",
     "pytest>=7.0.0",
+    "lark[interegular]>=1.2.2",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "gql[requests]>=3.5.0",
     "keyring>=25.6.0",
     "kivy>=2.3.1",
+    "lark[interegular]>=1.2.2",
     "python-dateutil>=2.8.0",
     "pyyaml>=6.0.2",
     "requests>=2.32.3",

--- a/src/treadi/data.py
+++ b/src/treadi/data.py
@@ -19,6 +19,7 @@ class Issue:
     url: str = ""
     # Has the current viewer looked at this issue or PR?
     is_read: bool = False
+    is_pr: bool = False
 
 
 def is_same_issue(l, r):

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -2,7 +2,7 @@
 # The syntax is a subset of github search filters
 # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
 
-start:  maybe_negated_statement (" " maybe_negated_statement)*
+start:  maybe_negated_statement (" "+ maybe_negated_statement)*
 
 # TODO forbid consecutive hypens, but maybe don't bother.
 #

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -1,0 +1,20 @@
+
+
+start:  maybe_negated_statement (" " maybe_negated_statement)*
+
+# TODO forbid consecutive hypens, but maybe don't bother.
+#
+#   "Username may only contain alphanumeric characters
+#   or single hyphens, and cannot begin or end with a hyphen."
+#
+USERNAME: /[a-zA-Z0-9]+([-a-zA-Z0-9]*[a-z0-9])?/
+
+maybe_negated_statement: "-"? statement
+
+statement: "type"       ":" ("issue" | "pr")
+         | "author"     ":" USERNAME
+         | "assignee"   ":" USERNAME
+         | "is"         ":" "draft"
+         | "review"     ":" ("none" | "approved" | "changes_requested")
+         | "repo"       ":" USERNAME "/" USERNAME
+ 

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -1,4 +1,6 @@
-
+# Filtering of issues and PRs
+# The syntax is a subset of github search filters
+# https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
 
 start:  maybe_negated_statement (" " maybe_negated_statement)*
 
@@ -29,6 +31,6 @@ CHANGES_REQUESTED: "changes_requested"
 type_stmt: "type" ":" (ISSUE | PR)
 author_stmt: "author" ":" USERNAME
 assignee_stmt: "assignee" ":" USERNAME
-is_stmt: "is" ":" DRAFT
+is_stmt: "is" ":" (DRAFT | ISSUE | PR)
 review_stmt: "review" ":" (NONE | APPROVED | CHANGES_REQUESTED)
 repo_stmt: "repo" ":" USERNAME "/" USERNAME

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -11,10 +11,16 @@ USERNAME: /[a-zA-Z0-9]+([-a-zA-Z0-9]*[a-z0-9])?/
 
 maybe_negated_statement: "-"? statement
 
-statement: "type"       ":" ("issue" | "pr")
-         | "author"     ":" USERNAME
-         | "assignee"   ":" USERNAME
-         | "is"         ":" "draft"
-         | "review"     ":" ("none" | "approved" | "changes_requested")
-         | "repo"       ":" USERNAME "/" USERNAME
+statement: type_stmt
+         | author_stmt
+         | assignee_stmt
+         | is_stmt
+         | review_stmt
+         | repo_stmt
  
+type_stmt: "type" ":" ("issue" | "pr")
+author_stmt: "author" ":" USERNAME
+assignee_stmt: "assignee" ":" USERNAME
+is_stmt: "is" ":" "draft"
+review_stmt: "review" ":" ("none" | "approved" | "changes_requested")
+repo_stmt: "repo" ":" USERNAME "/" USERNAME

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -8,8 +8,9 @@ start:  maybe_negated_statement (" " maybe_negated_statement)*
 #   or single hyphens, and cannot begin or end with a hyphen."
 #
 USERNAME: /[a-zA-Z0-9]+([-a-zA-Z0-9]*[a-z0-9])?/
+MINUS: "-"
 
-maybe_negated_statement: "-"? statement
+maybe_negated_statement: MINUS? statement
 
 statement: type_stmt
          | author_stmt
@@ -18,9 +19,16 @@ statement: type_stmt
          | review_stmt
          | repo_stmt
  
-type_stmt: "type" ":" ("issue" | "pr")
+ISSUE: "issue"
+PR: "pr"
+DRAFT: "draft"
+NONE: "none"
+APPROVED: "approved"
+CHANGES_REQUESTED: "changes_requested"
+
+type_stmt: "type" ":" (ISSUE | PR)
 author_stmt: "author" ":" USERNAME
 assignee_stmt: "assignee" ":" USERNAME
-is_stmt: "is" ":" "draft"
-review_stmt: "review" ":" ("none" | "approved" | "changes_requested")
+is_stmt: "is" ":" DRAFT
+review_stmt: "review" ":" (NONE | APPROVED | CHANGES_REQUESTED)
 repo_stmt: "repo" ":" USERNAME "/" USERNAME

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -1,0 +1,50 @@
+# Implemenation of filtering of displayed issuses, like a github filter
+# https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests
+# Usage:
+# f = Filter('type:issue label:"bug"')
+# cache.most_recent_issues(n=5, filter=f)
+
+
+# Query parsing
+# AND, OR, Paretheses - figure out later
+# Use a BNF grammar because that's the most principled
+# Start with type:issue or type:pr
+# Also do author:foobar because that's useful to me
+# Lark parser b/c I'm used to it
+
+import lark
+import pathlib
+
+GRAMMAR = (pathlib.Path(__file__).parent.resolve() / "filter.lark").read_text()
+PARSER = lark.Lark(GRAMMAR, parser="lalr", strict=True)
+
+
+def parse(filter: str):
+    tree = PARSER.parse(filter)
+
+
+class Query:
+
+    def __init__(self, query: str):
+        # TODO parse the query
+        pass
+
+    # Maybe classmethod for from string, with args to __init__ being implementation details
+    @classmethod
+    def from_string(cls, query: str) -> "Query":
+        # TODo parse the query
+        pass
+
+
+class Filter:
+
+    def __init__(self, query: str):
+        # TODO Validate query
+        self._query = Query(query)
+
+    def __call__(self, issue) -> bool:
+        """
+        Return True if the issue passes the filter
+        """
+        raise NotImplementedError
+        return False

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -1,7 +1,3 @@
-# Filtering of issues and PRs
-# The syntax is a subset of github search filters
-# https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests
-
 import lark
 import pathlib
 
@@ -94,6 +90,10 @@ class FilterTransformer(lark.Transformer):
         raise NotImplementedError
 
     def is_stmt(self, args):
+        if args[0] == "pr":
+            return require_pr
+        if args[0] == "issue":
+            return require_issue
         raise NotImplementedError
 
     def review_stmt(self, args):

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -4,7 +4,7 @@ import pathlib
 from treadi.data import Issue
 
 GRAMMAR = (pathlib.Path(__file__).parent.resolve() / "filter.lark").read_text()
-PARSER = lark.Lark(GRAMMAR, parser="lalr", strict=True)
+PARSER = lark.Lark(GRAMMAR, parser="lalr")
 
 
 def require_pr(issue: Issue):

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -1,50 +1,108 @@
-# Implemenation of filtering of displayed issuses, like a github filter
+# Filtering of issues and PRs
+# The syntax is a subset of github search filters
 # https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests
-# Usage:
-# f = Filter('type:issue label:"bug"')
-# cache.most_recent_issues(n=5, filter=f)
-
-
-# Query parsing
-# AND, OR, Paretheses - figure out later
-# Use a BNF grammar because that's the most principled
-# Start with type:issue or type:pr
-# Also do author:foobar because that's useful to me
-# Lark parser b/c I'm used to it
 
 import lark
 import pathlib
+
+from treadi.data import Issue
 
 GRAMMAR = (pathlib.Path(__file__).parent.resolve() / "filter.lark").read_text()
 PARSER = lark.Lark(GRAMMAR, parser="lalr", strict=True)
 
 
+def require_pr(issue: Issue):
+    """Return True if the issue is a PR."""
+    return issue.is_pr
+
+
+def require_issue(issue: Issue):
+    """Return True if the issue is an issue."""
+    return not issue.is_pr
+
+
+class RequireAuthor:
+
+    def __init__(self, author):
+        self._author = author
+
+    def __call__(self, issue: Issue):
+        """Return True if the issue is authored by this author."""
+        return self._author.lower() == issue.author.lower()
+
+
+class RequireRepo:
+
+    def __init__(self, owner, name):
+        self._owner = owner
+        self._name = name
+
+    def __call__(self, issue: Issue):
+        """Return True if the issue belongs to the given repo."""
+        return (
+            self._owner.lower() == issue.repo.owner.lower()
+            and self._name.lower() == issue.repo.name.lower()
+        )
+
+
+class InvertRequirement:
+
+    def __init__(self, requirement):
+        self._requirement = requirement
+
+    def __call__(self, issue: Issue):
+        """Return the opposite of what the requirement returns."""
+        return not self._requirement(issue)
+
+
+class RequireAll:
+
+    def __init__(self, requirements):
+        self._requirements = tuple(requirements)
+
+    def __call__(self, issue: Issue):
+        """Return True iff all requirements are met."""
+        for requirement in self._requirements:
+            if not requirement(issue):
+                return False
+        return True
+
+
+class FilterTransformer(lark.Transformer):
+    """Turn a lark parse tree into a callable that filters issues."""
+
+    def start(self, args):
+        return RequireAll(args)
+
+    def statement(self, args):
+        return args[0]
+
+    def maybe_negated_statement(self, args):
+        if args[0] == "-":
+            return InvertRequirement(args[1])
+        return args[0]
+
+    def type_stmt(self, args):
+        if args[0] == "pr":
+            return require_pr
+        return require_issue
+
+    def author_stmt(self, args):
+        return RequireAuthor(args[0].value)
+
+    def assignee_stmt(self, args):
+        raise NotImplementedError
+
+    def is_stmt(self, args):
+        raise NotImplementedError
+
+    def review_stmt(self, args):
+        raise NotImplementedError
+
+    def repo_stmt(self, args):
+        return RequireRepo(args[0].value, args[1].value)
+
+
 def parse(filter: str):
     tree = PARSER.parse(filter)
-
-
-class Query:
-
-    def __init__(self, query: str):
-        # TODO parse the query
-        pass
-
-    # Maybe classmethod for from string, with args to __init__ being implementation details
-    @classmethod
-    def from_string(cls, query: str) -> "Query":
-        # TODo parse the query
-        pass
-
-
-class Filter:
-
-    def __init__(self, query: str):
-        # TODO Validate query
-        self._query = Query(query)
-
-    def __call__(self, issue) -> bool:
-        """
-        Return True if the issue passes the filter
-        """
-        raise NotImplementedError
-        return False
+    return FilterTransformer().transform(tree)

--- a/src/treadi/issue_cache.py
+++ b/src/treadi/issue_cache.py
@@ -95,7 +95,8 @@ class IssueCache:
                 # True means it passes the filter
                 issues.append(i)
             if len(issues) >= n:
-                return issues
+                break
+        return issues
 
     def _sort(self):
         self.__upcomming.sort(reverse=True, key=lambda i: i.updated_at)

--- a/src/treadi/issue_cache.py
+++ b/src/treadi/issue_cache.py
@@ -62,13 +62,13 @@ class IssueCache:
                 self.__dismissed.append(u)
                 return
 
-    def most_recent_issues(self, n=1):
+    def most_recent_issues(self, n=1, filter=None):
         """
         Return the n most recently updated and not
         dismissed issues.
         """
         with self.__lock:
-            return self._most_recent_issues(n)
+            return self._most_recent_issues(n, filter)
 
     def newest_update_time(self):
         with self.__lock:
@@ -85,9 +85,17 @@ class IssueCache:
             return d[0].updated_at
         return u[0].updated_at
 
-    def _most_recent_issues(self, n):
+    def _most_recent_issues(self, n, filter):
         self._sort()
-        return self.__upcomming[:n]
+        if filter is None:
+            return self.__upcomming[:n]
+        issues = []
+        for i in self.__upcomming:
+            if filter(i):
+                # True means it passes the filter
+                issues.append(i)
+            if len(issues) >= n:
+                return issues
 
     def _sort(self):
         self.__upcomming.sort(reverse=True, key=lambda i: i.updated_at)

--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -9,7 +9,7 @@ from .data import Issue
 from .data import Repository
 
 
-def _make_issue(gh_data):
+def _make_issue(gh_data, is_pr=False):
     repo = Repository(
         owner=gh_data["repository"]["owner"]["login"],
         name=gh_data["repository"]["name"],
@@ -28,6 +28,7 @@ def _make_issue(gh_data):
         title=gh_data["title"],
         url=gh_data["url"],
         is_read=bool(gh_data["isReadByViewer"]),
+        is_pr=is_pr,
     )
 
 
@@ -217,7 +218,7 @@ class IssueLoader:
                         del issue_page_info[r]
                 if "pullRequests" in repo_result:
                     for pr in repo_result["pullRequests"]["nodes"]:
-                        self._cache.insert(_make_issue(pr))
+                        self._cache.insert(_make_issue(pr, is_pr=True))
                         pr_count += 1
                     if repo_result["pullRequests"]["pageInfo"]["hasNextPage"]:
                         pr_page_info[r] = repo_result["pullRequests"]["pageInfo"]
@@ -255,4 +256,4 @@ class IssueLoader:
 
         prs = self._client.execute(gql(make_query("is:pr")))
         for pr in prs["search"]["nodes"]:
-            self._cache.insert(_make_issue(pr))
+            self._cache.insert(_make_issue(pr, is_pr=True))

--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -128,8 +128,6 @@ class IssueScreen(Screen):
         self.ids.stack.clear_widgets()
         issue_cache = App.get_running_app().issue_cache
         issues = issue_cache.most_recent_issues(n=5, filter=self._filter)
-        if issues is None:
-            return
         for i in issues:
             self._add_issue(i)
 

--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -119,6 +119,11 @@ class IssueScreen(Screen):
 
         self._refresh_issues()
 
+    def on_text_changing(self):
+        # called hen on_text is called on filter TextInput
+        # Filters don't apply until the user hits enter, so display as yellow
+        self.ids.filter.background_color = (1, 1, 0.9, 1)
+
     def on_pre_enter(self):
         issue_cache = App.get_running_app().issue_cache
         self._refresh_issues()

--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -11,7 +11,7 @@ Config.set("graphics", "resizable", False)
 Config.set("input", "mouse", "mouse,disable_multitouch")
 from kivy.core.window import Window
 
-Window.size = (500, 518)
+Window.size = (500, 558)
 from kivy.properties import ColorProperty
 from kivy.properties import NumericProperty
 from kivy.properties import ObjectProperty
@@ -27,6 +27,7 @@ import webbrowser
 import requests
 import threading
 import time
+import logging
 import pathlib
 
 from gql import gql, Client
@@ -42,6 +43,7 @@ from .repo_loader import OrgRepoLoader
 from .repo_loader import FileRepoLoader
 from .repo_loader import SequentialRepoLoaders
 from .repo_loader import VcsRepoLoader
+from .filter import parse as parse_filter
 
 
 USERNAME = None
@@ -95,9 +97,39 @@ class IssueWidget(ButtonBehavior, BoxLayout):
 
 class IssueScreen(Screen):
 
+    def __init__(self, *args, **kwargs):
+        self._filter = None
+        self._logger = logging.getLogger("IssueLoader")
+        super().__init__(*args, **kwargs)
+
+    def validate_filter(self):
+        # Called when on_validate_text is called on filter TextInput
+        filter_str = self.ids.filter.text
+        if filter_str.strip() == "":
+            self._filter = None
+            self.ids.filter.background_color = (1, 1, 1, 1)
+        else:
+            try:
+                self._filter = parse_filter(filter_str.strip())
+                self.ids.filter.background_color = (0.9, 1, 0.9, 1)
+            except:
+                self._logger.exception("Cannot parse filter")
+                self._filter = None
+                self.ids.filter.background_color = (1, 0.5, 0.5, 1)
+
+        self._refresh_issues()
+
     def on_pre_enter(self):
         issue_cache = App.get_running_app().issue_cache
-        issues = issue_cache.most_recent_issues(n=5)
+        self._refresh_issues()
+
+    def _refresh_issues(self):
+        # Clear and re-add issues
+        self.ids.stack.clear_widgets()
+        issue_cache = App.get_running_app().issue_cache
+        issues = issue_cache.most_recent_issues(n=5, filter=self._filter)
+        if issues is None:
+            return
         for i in issues:
             self._add_issue(i)
 
@@ -116,7 +148,9 @@ class IssueScreen(Screen):
                 child_issues.append(child.issue)
 
         # aim for 1 additional issue, because one is being dismissed
-        consider_issues = issue_cache.most_recent_issues(n=1 + len(child_issues))
+        consider_issues = issue_cache.most_recent_issues(
+            n=1 + len(child_issues), filter=self._filter
+        )
         for itc in consider_issues:
             displaying_issue = False
             for chi in child_issues:

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -102,6 +102,7 @@
             hint_text: 'author:sloretz is:pr ...'
             multiline: False
             on_text_validate: root.validate_filter()
+            on_text: root.on_text_changing()
         StackLayout:
             id: stack
             orientation: "tb-lr"

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -91,11 +91,22 @@
 
 
 <IssueScreen>:
-    StackLayout:
-        id: stack
-        orientation: "tb-lr"
-        padding: '3dp'
-        spacing: '3dp'
+    BoxLayout:
+        orientation: "vertical"
+        padding: '0dp'
+        TextInput:
+            id: filter
+            size_hint: (None, None)
+            size: root.width, '40dp'
+            font_size: '17sp'
+            hint_text: 'author:sloretz is:pr ...'
+            multiline: False
+            on_text_validate: root.validate_filter()
+        StackLayout:
+            id: stack
+            orientation: "tb-lr"
+            padding: '3dp'
+            spacing: '3dp'
 
 
 <RepoPickerScreen>:

--- a/tests/test_filter_grammar.py
+++ b/tests/test_filter_grammar.py
@@ -1,0 +1,61 @@
+import lark
+
+import pytest
+
+from treadi.filter import GRAMMAR
+
+
+@pytest.fixture
+def parser():
+    return lark.Lark(GRAMMAR, parser="lalr", debug=True, strict=True)
+
+
+def test_negation(parser):
+    parser.parse("-type:issue")
+    parser.parse("-author:slorretz")
+    parser.parse("-repo:ros/rosdistro")
+
+
+def test_multiple(parser):
+    parser.parse("-type:issue author:sloretz -repo:ros/rodistro")
+
+
+def test_type(parser):
+    parser.parse("type:issue")
+    parser.parse("type:pr")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("type:foo")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("type: issue")
+
+
+def test_author(parser):
+    parser.parse("author:sloretz")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("author:-sloretz")
+
+
+def test_assignee(parser):
+    parser.parse("assignee:sloretz")
+    with pytest.raises(lark.UnexpectedCharacters):
+        parser.parse("assignee:*sloretz")
+
+
+def test_is(parser):
+    parser.parse("is:draft")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("is:candy")
+
+
+def test_review(parser):
+    parser.parse("review:none")
+    parser.parse("review:approved")
+    parser.parse("review:changes_requested")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("review:candy")
+
+
+def test_repo(parser):
+    parser.parse("repo:sloretz/TreadI")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("repo:sloretz")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,71 @@
+from treadi.data import Issue
+from treadi.data import Repository
+import treadi.filter as tf
+
+REPO_ROS_ROSDITRO = Repository(
+    owner="ros",
+    name="rosdistro",
+)
+REPO_ROS2_ROS2 = Repository(
+    owner="ros2",
+    name="ros2",
+)
+ISSUE_ROS_ROSDISTRO = Issue(
+    repo=REPO_ROS_ROSDITRO,
+    author="sloretz",
+    created_at=None,
+    updated_at=None,
+    number=42,
+    title="fix stuff",
+    url="",
+    is_read=False,
+    is_pr=False,
+)
+PR_ROS_ROSDISTRO = Issue(
+    repo=REPO_ROS_ROSDITRO,
+    author="ghost",
+    created_at=None,
+    updated_at=None,
+    number=1,
+    title="break stuff",
+    url="",
+    is_read=False,
+    is_pr=True,
+)
+
+
+def test_require_pr():
+    assert tf.require_pr(PR_ROS_ROSDISTRO)
+    assert not tf.require_pr(ISSUE_ROS_ROSDISTRO)
+
+
+def test_require_issue():
+    assert tf.require_issue(ISSUE_ROS_ROSDISTRO)
+    assert not tf.require_issue(PR_ROS_ROSDISTRO)
+
+
+def test_require_author():
+    assert tf.RequireAuthor("sloretz")(ISSUE_ROS_ROSDISTRO)
+    assert not tf.RequireAuthor("bob")(ISSUE_ROS_ROSDISTRO)
+
+
+def test_require_repo():
+    assert tf.RequireRepo("ros", "rosdistro")(ISSUE_ROS_ROSDISTRO)
+    assert not tf.RequireRepo("ros2", "ros2")(ISSUE_ROS_ROSDISTRO)
+
+
+def test_invert_requirement():
+    assert not tf.InvertRequirement(tf.require_pr)(PR_ROS_ROSDISTRO)
+    assert tf.InvertRequirement(tf.require_pr)(ISSUE_ROS_ROSDISTRO)
+
+
+def test_require_all():
+    assert tf.RequireAll([tf.RequireAuthor("sloretz"), tf.require_issue])(
+        ISSUE_ROS_ROSDISTRO
+    )
+    assert not tf.RequireAll([tf.RequireAuthor("ghost"), tf.require_issue])(
+        PR_ROS_ROSDISTRO
+    )
+    assert not tf.RequireAll([tf.RequireAuthor("sloretz"), tf.require_issue])(
+        PR_ROS_ROSDISTRO
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -923,7 +923,6 @@ dependencies = [
     { name = "gql", extra = ["requests"] },
     { name = "keyring" },
     { name = "kivy" },
-    { name = "lark", extra = ["interegular"] },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -932,6 +931,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "lark", extra = ["interegular"] },
     { name = "pytest" },
 ]
 
@@ -940,7 +940,6 @@ requires-dist = [
     { name = "gql", extras = ["requests"], specifier = ">=3.5.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "kivy", specifier = ">=2.3.1" },
-    { name = "lark", extras = ["interegular"], specifier = ">=1.2.2" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
@@ -949,6 +948,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=25.1.0" },
+    { name = "lark", extras = ["interegular"], specifier = ">=1.2.2" },
     { name = "pytest", specifier = ">=7.0.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -318,6 +318,15 @@ wheels = [
 ]
 
 [[package]]
+name = "interegular"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/9d/8b6dde58a028a3962ce17e84d5fe73758df61378e00ef8ac3d85da34b0ff/interegular-0.3.3.tar.gz", hash = "sha256:d9b697b21b34884711399ba0f0376914b81899ce670032486d0d048344a76600", size = 24705 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/01/72d6472f80651673716d1deda2a5bbb633e563ecf94f4479da5519d69d25/interegular-0.3.3-py37-none-any.whl", hash = "sha256:b0c07007d48c89d6d19f7204972d369b2a77222722e126b6aa63aa721dc3b19c", size = 23635 },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +472,20 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/55/cd1555bde62f809219cbc5d8a0836b0293399da2f4ba4e8ee84b6a7cc393/Kivy_Garden-0.1.5-py3-none-any.whl", hash = "sha256:ef50f44b96358cf10ac5665f27a4751bb34ef54051c54b93af891f80afe42929", size = 4623 },
+]
+
+[[package]]
+name = "lark"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/60/bc7622aefb2aee1c0b4ba23c1446d3e30225c8770b38d7aedbfb65ca9d5a/lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80", size = 252132 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/00/d90b10b962b4277f5e64a78b6609968859ff86889f5b898c1a778c06ec00/lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c", size = 111036 },
+]
+
+[package.optional-dependencies]
+interegular = [
+    { name = "interegular" },
 ]
 
 [[package]]
@@ -900,6 +923,7 @@ dependencies = [
     { name = "gql", extra = ["requests"] },
     { name = "keyring" },
     { name = "kivy" },
+    { name = "lark", extra = ["interegular"] },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -916,6 +940,7 @@ requires-dist = [
     { name = "gql", extras = ["requests"], specifier = ">=3.5.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "kivy", specifier = ">=2.3.1" },
+    { name = "lark", extras = ["interegular"], specifier = ">=1.2.2" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },


### PR DESCRIPTION
This adds filtering of issues using a subset of the github search syntax. It can't be the full syntax because I'm doing this clientside, and TreadI doesn't pull all that much information about issues.

Supported syntax examples:

```
type:pr
type issue
is:pr
is:issue
author:sloretz
repo:ros/rosdisto
```

And it supports negatives

```
-repo:ros/rosdistro
```

And multiple filters by joining with whitespace

```
author:sloretz is:pr
```