### PR TITLE
Filter by organization with org:

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Filter issues and PRs with a subset of the familiar [Github search syntax](https
 * `author:USERNAME` - Show issues and PRs opened by a user
 * `is:issue` - Show only Issues
 * `is:issue` - Show only PRs
+* `org:OWNER` - Show only PRs from the given organization or user
 * `repo:owner/name` - Show only things from the repo `owner/name`
 * `type:issue` - Same as `is:issue`
 * `type:pr` - Same as `is:pr`

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -21,6 +21,7 @@ statement: type_stmt
          | is_stmt
          | review_stmt
          | repo_stmt
+         | org_stmt
  
 ISSUE: "issue"
 PR: "pr"
@@ -35,3 +36,4 @@ assignee_stmt: "assignee" ":" USERNAME
 is_stmt: "is" ":" (DRAFT | ISSUE | PR)
 review_stmt: "review" ":" (NONE | APPROVED | CHANGES_REQUESTED)
 repo_stmt: "repo" ":" USERNAME "/" REPOSITORY_NAME
+org_stmt: "org" ":" USERNAME

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -41,6 +41,16 @@ class RequireRepo:
         )
 
 
+class RequireOrg:
+
+    def __init__(self, org):
+        self._org = org
+
+    def __call__(self, issue: Issue):
+        """Return True if the issue belongs to the given organization."""
+        return self._org.lower() == issue.repo.owner.lower()
+
+
 class InvertRequirement:
 
     def __init__(self, requirement):
@@ -101,6 +111,9 @@ class FilterTransformer(lark.Transformer):
 
     def repo_stmt(self, args):
         return RequireRepo(args[0].value, args[1].value)
+
+    def org_stmt(self, args):
+        return RequireOrg(args[0].value)
 
 
 def parse(filter: str):

--- a/tests/test_filter_grammar.py
+++ b/tests/test_filter_grammar.py
@@ -61,3 +61,10 @@ def test_repo(parser):
     parser.parse("repo:sloretz/..--__Hello1")
     with pytest.raises(lark.UnexpectedToken):
         parser.parse("repo:sloretz")
+
+
+def test_rorg(parser):
+    parser.parse("org:ros2")
+    parser.parse("org:ros-visualization")
+    with pytest.raises(lark.UnexpectedToken):
+        parser.parse("org:slo_retz")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -54,6 +54,11 @@ def test_require_repo():
     assert not tf.RequireRepo("ros2", "ros2")(ISSUE_ROS_ROSDISTRO)
 
 
+def test_require_repo():
+    assert tf.RequireOrg("ros")(ISSUE_ROS_ROSDISTRO)
+    assert not tf.RequireOrg("ros2")(ISSUE_ROS_ROSDISTRO)
+
+
 def test_invert_requirement():
     assert not tf.InvertRequirement(tf.require_pr)(PR_ROS_ROSDISTRO)
     assert tf.InvertRequirement(tf.require_pr)(ISSUE_ROS_ROSDISTRO)


### PR DESCRIPTION
This adds a new filter `org:` to the issue filters. It lets one filter repositories by the organization or user that owns them.