### PR TITLE
Press escape to go back to repo picker screen

### DIFF
--- a/src/treadi/screens/issue_loading_screen.py
+++ b/src/treadi/screens/issue_loading_screen.py
@@ -4,6 +4,7 @@ from kivy.properties import NumericProperty
 from kivy.uix.screenmanager import Screen
 
 from ..issue_loader import IssueLoader
+from .issue_screen import IssueScreen
 
 
 class IssueLoadingScreen(Screen):
@@ -17,6 +18,8 @@ class IssueLoadingScreen(Screen):
             App.get_running_app().issue_cache,
             self.update_progress,
         )
+        if "name" not in kwargs:
+            kwargs["name"] = "issue-loading-screen"
         super().__init__(**kwargs)
 
     def update_progress(self, progress):
@@ -26,5 +29,4 @@ class IssueLoadingScreen(Screen):
 
     def switch_to_issues(self):
         # Must only be called on main thread
-        self.manager.transition.direction = "left"
-        self.manager.current = "issues"
+        self.manager.switch_to(IssueScreen(), direction="left")

--- a/src/treadi/screens/issue_screen.py
+++ b/src/treadi/screens/issue_screen.py
@@ -3,6 +3,7 @@ import webbrowser
 
 from kivy.animation import Animation
 from kivy.app import App
+from kivy.core.window import Window
 from kivy.properties import ColorProperty
 from kivy.properties import ObjectProperty
 from kivy.uix.behaviors import ButtonBehavior
@@ -49,7 +50,9 @@ class IssueScreen(Screen):
 
     def __init__(self, *args, **kwargs):
         self._filter = None
-        self._logger = logging.getLogger("IssueLoader")
+        self._logger = logging.getLogger("IssueScreen")
+        if "name" not in kwargs:
+            kwargs["name"] = "issues-screen"
         super().__init__(*args, **kwargs)
 
     def validate_filter(self):
@@ -77,6 +80,15 @@ class IssueScreen(Screen):
     def on_pre_enter(self):
         issue_cache = App.get_running_app().issue_cache
         self._refresh_issues()
+        Window.bind(on_key_down=self.on_key_down)
+
+    def on_pre_leave(self):
+        Window.unbind(on_key_down=self.on_key_down)
+
+    def on_key_down(self, window, key, scancode, codepoint, modifiers):
+        if key == 27:  # ESCAPE KEY
+            # TODO modal dialog to confirm
+            App.get_running_app().switch_to_pick_repos(direction="right")
 
     def _refresh_issues(self):
         # Clear and re-add issues

--- a/src/treadi/screens/issue_screen.py
+++ b/src/treadi/screens/issue_screen.py
@@ -20,7 +20,7 @@ class IssueScreenGoBackPopup(Popup):
 
     def on_go_back(self):
         App.get_running_app().switch_to_pick_repos(direction="right")
-        self.dismiss()
+        self.dismiss(animation=False)
 
 
 class IssueWidget(ButtonBehavior, BoxLayout):
@@ -105,9 +105,9 @@ class IssueScreen(Screen):
             if self._popup is None:
                 self._popup = IssueScreenGoBackPopup()
                 self._popup.bind(on_dismiss=self._forget_popup)
-                self._popup.open()
+                self._popup.open(animation=False)
             else:
-                self._popup.dismiss()
+                self._popup.dismiss(animation=False)
 
     def _refresh_issues(self):
         # Clear and re-add issues

--- a/src/treadi/screens/repo_loading_screen.py
+++ b/src/treadi/screens/repo_loading_screen.py
@@ -8,13 +8,17 @@ class RepoLoadingScreen(Screen):
 
     def __init__(self, loader, **kwargs):
         self._loader = loader
-        self._loader.begin_loading(self.switch_to_issue_loading)
+        if "name" not in kwargs:
+            kwargs["name"] = "repo-loading-screen"
         super().__init__(**kwargs)
+
+    def on_pre_enter(self):
+        self._loader.begin_loading(self.switch_to_issue_loading)
 
     def switch_to_issue_loading(self, repos):
 
         def _switch(dt):
-            self.manager.switch_to(IssueLoadingScreen(repos))
+            self.manager.switch_to(IssueLoadingScreen(repos), direction="left")
 
         Clock.schedule_once(lambda dt: self._loader.cleanup())
         Clock.schedule_once(_switch)

--- a/src/treadi/screens/repo_picker_screen.py
+++ b/src/treadi/screens/repo_picker_screen.py
@@ -26,6 +26,8 @@ class RepoPickerScreen(Screen):
 
     def __init__(self, *args, **kwargs):
         self._config = config.Config()
+        if "name" not in kwargs:
+            kwargs["name"] = "repo-picker-screen"
         super().__init__(*args, **kwargs)
 
     def on_pre_enter(self):
@@ -40,4 +42,4 @@ class RepoPickerScreen(Screen):
             # TODO pass this into repo loader
             gql_client=App.get_running_app().gql_client,
         )
-        self.manager.switch_to(RepoLoadingScreen(repo_loader))
+        self.manager.switch_to(RepoLoadingScreen(repo_loader), direction="left")

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -113,14 +113,15 @@
 <IssueScreenGoBackPopup>
     auto_dismiss: False
     title: "Go to repository lists?"
+    size_hint: (0.7, 0.7)
 
     BoxLayout:
         orientation: "vertical"
 
         Label:
             size_hint_y: 0.8
-            font_size: '15sp'
-            text: "Are you sure you want to go back to the repository lists?\n\nIf you go back to the repository lists and then return to this same list, you will have to load all issues and PRs again. If you dismissed any issues or PRs, they won't be dismissed when you return."
+            font_size: '18sp'
+            text: "Are you sure you want to go back to the repository lists?\n\nIf you decide to return to this same list, you will have to load all issues and PRs again. Any issues or PRs you dismissed will no longer be dismissed when you return."
             text_size: self.size
             halign: 'center'
             valign: 'middle'

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -110,6 +110,38 @@
             spacing: '3dp'
 
 
+<IssueScreenGoBackPopup>
+    auto_dismiss: False
+    title: "Go to repository lists?"
+
+    BoxLayout:
+        orientation: "vertical"
+
+        Label:
+            size_hint_y: 0.8
+            font_size: '15sp'
+            text: "Are you sure you want to go back to the repository lists?\n\nIf you go back to the repository lists and then return to this same list, you will have to load all issues and PRs again. If you dismissed any issues or PRs, they won't be dismissed when you return."
+            text_size: self.size
+            halign: 'center'
+            valign: 'middle'
+
+        BoxLayout:
+            size_hint_y: 0.2
+            orientation: "horizontal"
+
+            Button:
+                size_hint_x: 0.7
+                text: "Yes I'm sure"
+                font_size: '24sp'
+                on_release: root.on_go_back()
+
+            Button:
+                size_hint_x: 0.3
+                text: "No"
+                font_size: '24sp'
+                on_release: root.dismiss()
+
+
 <RepoPickerScreen>:
     StackLayout:
         id: stack

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -139,7 +139,7 @@
                 size_hint_x: 0.3
                 text: "No"
                 font_size: '24sp'
-                on_release: root.dismiss()
+                on_release: root.dismiss(animation=False)
 
 
 <RepoPickerScreen>:


### PR DESCRIPTION
This PR makes it so the escape key goes back to the repo picker screen.

Alternative to #19 - I like not having the distraction of a visible back button

Fixes #15 