### PR TITLE
Title bar says the repo list name

### DIFF
--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -68,7 +68,7 @@ class TreadIApp(App):
     def switch_to_pick_repos(self, direction="left"):
         """Called to switch to repo picker screen and reset."""
         # Reset title away from repo list name
-        self.title = 'TreadI'
+        self.title = "TreadI"
         # This avoids a circular dependency in screen modules
         issue_loader = None
         issue_cache = IssueCache()

--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -67,6 +67,8 @@ class TreadIApp(App):
 
     def switch_to_pick_repos(self, direction="left"):
         """Called to switch to repo picker screen and reset."""
+        # Reset title away from repo list name
+        self.title = 'TreadI'
         # This avoids a circular dependency in screen modules
         issue_loader = None
         issue_cache = IssueCache()

--- a/src/treadi/screens/repo_picker_screen.py
+++ b/src/treadi/screens/repo_picker_screen.py
@@ -43,3 +43,4 @@ class RepoPickerScreen(Screen):
             gql_client=App.get_running_app().gql_client,
         )
         self.manager.switch_to(RepoLoadingScreen(repo_loader), direction="left")
+        App.get_running_app().title += f": {display_name}"


### PR DESCRIPTION
This PR makes the title bar either say `TreadI` before a repo list is chosen, or `TreadI: Name of list`. For example: `TreadI: OSRA ros-controls PMC`. This makes it faster to look at a treadi window and tell what list is being displayed.