### PR TITLE
Support authenticating with Personal Access Tokens

### DIFF
--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -143,6 +143,28 @@
                 on_release: root.dismiss(animation=False)
 
 
+<InvalidTokenPopup>
+    auto_dismiss: False
+    title: "Invalid token"
+    size_hint: (0.7, 0.7)
+
+    BoxLayout:
+        orientation: "vertical"
+        Label:
+            size_hint_y: 0.8
+            font_size: '18sp'
+            text: "TreadI is unable to authenticate with the Github API. Did your personal access token expire?"
+            text_size: self.size
+            halign: 'center'
+            valign: 'middle'
+
+        Button:
+            size_hint_y: 0.2
+            text: "Exit TreadI"
+            font_size: '24sp'
+            on_release: root.dismiss()
+
+
 <RepoPickerScreen>:
     StackLayout:
         id: stack


### PR DESCRIPTION
The device flow and TreadI Github Aapp is fine, but there are some advantages to a PAT:

* The TreadI Github App cannot access private repos ever. A PAT can if you give it access. Maybe you want to use TreadI with a Private repo?
* Github Apps have unhelpful "Can Act on your behalf" that's not actually true for minimum permission Github Apps like TreadI. This gives an alternative to someone who doesn't like the sound of that message https://github.com/orgs/community/discussions/37117


If the PAT doesn't work then TreadI Displays an error and lets you exit.

To start using a PAT:

1. Create a fine-grained access token with no permissions besides the default.
2. Save it in the keyring using the command `keyring set TreadI GithubPersonalAccessToken`


To stop using a PAT and go back to Device Flow auth:

`keyring del TreadI GithubPersonalAccessToken`


Fixes #12 

