### PR TITLE
Make sure issue loader stops when going back to repo screen

### DIFF
--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -153,6 +153,10 @@ class IssueLoader:
         self._thread = threading.Thread(daemon=True, target=self._run)
         self._progress_callback = progress_callback
         self._thread.start()
+        self._stop = False
+
+    def stop(self):
+        self._stop = True
 
     def _run(self):
         try:
@@ -161,13 +165,15 @@ class IssueLoader:
             )
         except:
             self._logger.exception("Exception in IssueLoader thread")
-        while True:
-            time.sleep(15)
+        time.sleep(15)
+        while not self._stop:
             try:
                 # Uses search API to get updated issues and PRs
                 self._update_all_issues()
             except:
                 self._logger.exception("Exception in IssueLoader thread")
+            time.sleep(15)
+        self._logger.debug("IssueLoader thread exiting")
 
     def _load_all_issues(self, repos_per_query, progress_callback=None):
         num_repos_at_start = len(self._repos)

--- a/src/treadi/main.py
+++ b/src/treadi/main.py
@@ -95,8 +95,10 @@ class TreadIApp(App):
         # Reset title away from repo list name
         self.title = "TreadI"
         # This avoids a circular dependency in screen modules
-        issue_loader = None
-        issue_cache = IssueCache()
+        if self.issue_loader is not None:
+            self.issue_loader.stop()
+        self.issue_loader = None
+        self.issue_cache = IssueCache()
         self.sm.transition.direction = direction
         self.sm.switch_to(RepoPickerScreen())
 


### PR DESCRIPTION
Currently if you use `escape` to go back to the repo screen, the old issue loader thread keeps trying to search for issues. This PR puts a stop to that.