### PR TITLE
Add "About TreadI" screen that shows version and repository_lists.d path

### DIFF
--- a/docs/reference/custom-repository-list.md
+++ b/docs/reference/custom-repository-list.md
@@ -11,16 +11,21 @@ Create a new list in the `repository_lists.d/` directory.
 TreadI creates this directory the first time it is run.
 The location of the directory depends on your operating system.
 
+Hit `[shift]` + `/` at the repository lists screen to open a dialog that shows the path.
+
 **Linux:**
+
+On Linux, TreadI will use a path like:
 
 ```
 ~/.config/TreadI/repository_lists.d
 ```
 
-*Note, the location respects the value of `XDG_CONFIG_HOME` or `XDG_HOME`.*
-*If you don't see `~/.config/TreadI` after you run TreadI once, then it has been created somewhere else according to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).*
+The location respects the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
 
 **OSX:**
+
+On OSX, TreadI will use a path like:
 
 ```
 /Users/YOUR USERNAME/Library/Application Support/TreadI/repository_lists.d
@@ -28,20 +33,15 @@ The location of the directory depends on your operating system.
 
 **Windows:**
 
-If you have a Windows machine, please run the following Python code to determine the config directory path.
-Then, please [open a PR to update this documentation](https://github.com/sloretz/TreadI).
+If you have a Windows machine, then please [open a PR to update this documentation](https://github.com/sloretz/TreadI).
 
-```python
-from pathlib import Path
-from platformdirs import user_config_dir
-
-base = Path(user_config_dir("TreadI"))
-print(base / Path("repository_lists.d"))
+```
+C:/Put/path/you/see/TreadI/use/here/repository_lists.d
 ```
 
 ## Create a repository list
 
-To create a custom repository list, create a file in `repository_lists.d/` with a name like this:
+Create a custom repository list by creating a file in `repository_lists.d/` with a name like this:
 
 ```
 XX_Some_Name.txt

--- a/src/treadi/config.py
+++ b/src/treadi/config.py
@@ -92,11 +92,14 @@ class Config:
     def __init__(self):
         self._logger = logging.getLogger("Config")
 
+    @property
+    def repository_lists_dir(self):
+        return config_dir() / _REPO_LIST_DIR
+
     def repository_list_names(self):
         """Return a list of repository list display names."""
-        repo_list_d = config_dir() / _REPO_LIST_DIR
         rank_name = []
-        for file in repo_list_d.iterdir():
+        for file in self.repository_lists_dir.iterdir():
             if file.name == "README.md":
                 continue
             match = _REPO_LIST_REGEX.match(file.name)
@@ -120,8 +123,7 @@ class Config:
 
         raise RuntimeError if a repository list is not found.
         """
-        repo_list_d = config_dir() / _REPO_LIST_DIR
-        for file in repo_list_d.iterdir():
+        for file in self.repository_lists_dir.iterdir():
             match = _REPO_LIST_REGEX.match(file.name)
             if match is None:
                 self._logger.warning(f"Invalid repository list file name: {file.name}")

--- a/src/treadi/screens/repo_picker_screen.py
+++ b/src/treadi/screens/repo_picker_screen.py
@@ -1,5 +1,9 @@
+from importlib.metadata import version
+
 from kivy.app import App
+from kivy.core.window import Window
 from kivy.uix.button import Button
+from kivy.uix.popup import Popup
 from kivy.uix.screenmanager import Screen
 
 from .. import config
@@ -22,9 +26,18 @@ class RepoButton(Button):
         self._repo_picker.use_repo_list(self._display_name)
 
 
+class RepoPickerScreenHelpPopup(Popup):
+
+    def __init__(self, config):
+        self._version = version('TreadI')
+        self._config = config
+        super().__init__()
+
+
 class RepoPickerScreen(Screen):
 
     def __init__(self, *args, **kwargs):
+        self._popup = None
         self._config = config.Config()
         if "name" not in kwargs:
             kwargs["name"] = "repo-picker-screen"
@@ -34,6 +47,23 @@ class RepoPickerScreen(Screen):
         for name in self._config.repository_list_names():
             btn = RepoButton(repo_picker=self, text=name)
             self.ids.stack.add_widget(btn)
+        Window.bind(on_key_down=self.on_key_down)
+
+    def on_pre_leave(self):
+        Window.unbind(on_key_down=self.on_key_down)
+
+    def on_key_down(self, window, key, scancode, codepoint, modifiers):
+        if key == 47 and 'shift' in modifiers:  # ? KEY
+            if self._popup is None:
+                self._popup = RepoPickerScreenHelpPopup(self._config)
+                self._popup.bind(on_dismiss=self._forget_popup)
+                self._popup.open(animation=False)
+                print("Opening popup")
+            else:
+                self._popup.dismiss(animation=False)
+
+    def _forget_popup(self, _):
+        self._popup = None
 
     def use_repo_list(self, display_name):
         repo_list = self._config.repository_list(display_name)

--- a/src/treadi/screens/repo_picker_screen.py
+++ b/src/treadi/screens/repo_picker_screen.py
@@ -29,7 +29,7 @@ class RepoButton(Button):
 class RepoPickerScreenHelpPopup(Popup):
 
     def __init__(self, config):
-        self._version = version('TreadI')
+        self._version = version("TreadI")
         self._config = config
         super().__init__()
 
@@ -53,7 +53,7 @@ class RepoPickerScreen(Screen):
         Window.unbind(on_key_down=self.on_key_down)
 
     def on_key_down(self, window, key, scancode, codepoint, modifiers):
-        if key == 47 and 'shift' in modifiers:  # ? KEY
+        if key == 47 and "shift" in modifiers:  # ? KEY
             if self._popup is None:
                 self._popup = RepoPickerScreenHelpPopup(self._config)
                 self._popup.bind(on_dismiss=self._forget_popup)

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -216,6 +216,41 @@
             font_size: '24sp'
             on_release: root.dismiss()
 
+<RepoPickerScreenHelpPopup>:
+    auto_dismiss: False
+    title: "Repository Picker Help"
+    size_hint: (1, 0.7)
+
+    BoxLayout:
+        orientation: "vertical"
+        Label:
+            size_hint_y: 0.1
+            text: "TreadI Version"
+            font_size: '18sp'
+        Label:
+            size_hint_y: 0.1
+            font_size: '18sp'
+            text: root._version
+            text_size: self.size
+            halign: 'center'
+            valign: 'middle'
+        Label:
+            size_hint_y: 0.1
+            text: "Location of repository_lists.d"
+            font_size: '18sp'
+        Label:
+            size_hint_y: 0.1
+            font_size: '15sp'
+            text: str(root._config.repository_lists_dir)
+            text_size: self.size
+            halign: 'center'
+            valign: 'middle'
+
+        Button:
+            size_hint_y: 0.2
+            text: "Close Help"
+            font_size: '24sp'
+            on_release: root.dismiss()
 
 <RepoPickerScreen>:
     StackLayout:

--- a/src/treadi/treadi.kv
+++ b/src/treadi/treadi.kv
@@ -218,37 +218,20 @@
 
 <RepoPickerScreenHelpPopup>:
     auto_dismiss: False
-    title: "Repository Picker Help"
+    title: "About TreadI"
     size_hint: (1, 0.7)
 
     BoxLayout:
         orientation: "vertical"
-        Label:
-            size_hint_y: 0.1
-            text: "TreadI Version"
-            font_size: '18sp'
-        Label:
-            size_hint_y: 0.1
-            font_size: '18sp'
-            text: root._version
-            text_size: self.size
-            halign: 'center'
-            valign: 'middle'
-        Label:
-            size_hint_y: 0.1
-            text: "Location of repository_lists.d"
-            font_size: '18sp'
-        Label:
-            size_hint_y: 0.1
+        TextInput:
+            size_hint_y: 0.9
+            readonly: True
+            text: "Version: " + root._version + "\nRepository lists directory:\n\t" + str(root._config.repository_lists_dir)
             font_size: '15sp'
-            text: str(root._config.repository_lists_dir)
-            text_size: self.size
-            halign: 'center'
-            valign: 'middle'
 
         Button:
-            size_hint_y: 0.2
-            text: "Close Help"
+            size_hint_y: 0.1
+            text: "Close"
             font_size: '24sp'
             on_release: root.dismiss()
 


### PR DESCRIPTION
This adds an "About TreadI" screen. Access it by hitting "[shift]" + "/" (this is `?` on a US keyboard) at the repo picker screen to access it.