### PR TITLE
Flter pull requests by the branch they target with base:

### DIFF
--- a/docs/reference/filter-syntax.md
+++ b/docs/reference/filter-syntax.md
@@ -137,6 +137,24 @@ org:ros2
 repo:ros/rosdistro
 ```
 
+### Show pull requests targeting a specific branch name
+
+Note, this does NOT exclude issues.
+
+*Example: Show issues and pull requests that target branches whose names start with `rolling`*
+
+```
+base:rolling
+```
+
+Combine with `is:pr` to show only pull requests.
+
+*Example: Show only pull requests that target branches whose names start with `rolling`*
+
+```
+is:pr base:rolling
+```
+
 ### Invert a filter
 
 Invert any filter by prepending a `-` character.

--- a/src/treadi/data.py
+++ b/src/treadi/data.py
@@ -26,6 +26,7 @@ class PullRequest(Issue):
     approved: bool = False
     changes_requested: bool = False
     draft: bool = False
+    base_ref: str = ""
 
 
 def is_same_issue(l, r):

--- a/src/treadi/filter.lark
+++ b/src/treadi/filter.lark
@@ -12,6 +12,8 @@ start:  maybe_negated_statement (" "+ maybe_negated_statement)*
 USERNAME: /[a-zA-Z0-9]+([-a-zA-Z0-9]*[a-z0-9])?/
 REPOSITORY_NAME: /[-._a-zA-Z0-9]+/
 MINUS: "-"
+# TODO too permissive is ok, but this is probably not permissive enough
+GIT_BRANCH: /[-._@{}a-zA-Z\/0-9]+/
 
 maybe_negated_statement: MINUS? statement
 
@@ -22,6 +24,7 @@ statement: type_stmt
          | review_stmt
          | repo_stmt
          | org_stmt
+         | base_stmt
  
 ISSUE: "issue"
 PR: "pr"
@@ -37,3 +40,4 @@ is_stmt: "is" ":" (DRAFT | ISSUE | PR)
 review_stmt: "review" ":" (NONE | APPROVED | CHANGES_REQUESTED)
 repo_stmt: "repo" ":" USERNAME "/" REPOSITORY_NAME
 org_stmt: "org" ":" USERNAME
+base_stmt: "base" ":" GIT_BRANCH

--- a/src/treadi/filter.py
+++ b/src/treadi/filter.py
@@ -124,6 +124,22 @@ class RequireOrg(Requirement):
         return self._org.lower() == issue_or_pr.repo.owner.lower()
 
 
+class RequireBaseBeginsWith(Requirement):
+
+    def __init__(self, base_prefix):
+        self._base_prefix = base_prefix
+
+    def __call__(self, issue_or_pr) -> bool:
+        if issue_or_pr.is_pr:
+            return issue_or_pr.base_ref.startswith(self._base_prefix)
+        return True
+
+    def invert(self, issue_or_pr) -> bool:
+        if issue_or_pr.is_pr:
+            return not self(issue_or_pr)
+        return True
+
+
 class Invert(Requirement):
 
     def __init__(self, requirement):
@@ -193,6 +209,9 @@ class FilterTransformer(lark.Transformer):
 
     def org_stmt(self, args):
         return RequireOrg(args[0].value)
+
+    def base_stmt(self, args):
+        return RequireBaseBeginsWith(args[0].value)
 
 
 def parse(filter: str):

--- a/src/treadi/issue_loader.py
+++ b/src/treadi/issue_loader.py
@@ -46,6 +46,7 @@ def _make_pr(gh_data):
         approved=approved,
         changes_requested=changes_requested,
         draft=bool(gh_data["isDraft"]),
+        base_ref=gh_data["baseRefName"],
         **_make_issue_kwargs(gh_data),
     )
 
@@ -90,6 +91,7 @@ fragment prFields on PullRequest {
             }
         }
     }
+    baseRefName
     repository {
         name
         owner {

--- a/tests/test_filter_grammar.py
+++ b/tests/test_filter_grammar.py
@@ -63,8 +63,15 @@ def test_repo(parser):
         parser.parse("repo:sloretz")
 
 
-def test_rorg(parser):
+def test_org(parser):
     parser.parse("org:ros2")
     parser.parse("org:ros-visualization")
     with pytest.raises(lark.UnexpectedToken):
         parser.parse("org:slo_retz")
+
+
+def test_base(parser):
+    parser.parse("base:ros2")
+    parser.parse("base:ros-visualization")
+    parser.parse("base:slo_retz")
+    parser.parse("base:slo/retz")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -32,6 +32,7 @@ PR_ROS_ROSDISTRO = PullRequest(
     title="break stuff",
     url="",
     is_pr=True,
+    base_ref="rolling",
 )
 DRAFT_PR_ROS_ROSDISTRO = PullRequest(
     repo=REPO_ROS_ROSDITRO,
@@ -43,6 +44,7 @@ DRAFT_PR_ROS_ROSDISTRO = PullRequest(
     url="",
     is_pr=True,
     draft=True,
+    base_ref="main",
 )
 APPROVED_PR_ROS_ROSDISTRO = PullRequest(
     repo=REPO_ROS_ROSDITRO,
@@ -54,6 +56,7 @@ APPROVED_PR_ROS_ROSDISTRO = PullRequest(
     url="",
     is_pr=True,
     approved=True,
+    base_ref="master",
 )
 CHANGES_REQUESTED_PR_ROS_ROSDISTRO = PullRequest(
     repo=REPO_ROS_ROSDITRO,
@@ -65,6 +68,7 @@ CHANGES_REQUESTED_PR_ROS_ROSDISTRO = PullRequest(
     url="",
     is_pr=True,
     changes_requested=True,
+    base_ref="rolling",
 )
 
 
@@ -97,6 +101,23 @@ def test_require_draft_if_pr():
     assert f(ISSUE_ROS_ROSDISTRO)
     assert not f(PR_ROS_ROSDISTRO)
     assert f(DRAFT_PR_ROS_ROSDISTRO)
+
+
+def test_require_base_if_pr():
+    f = tf.parse("base:roll")
+    fnot = tf.parse("-base:roll")
+
+    rolling_pr = copy.deepcopy(PR_ROS_ROSDISTRO)
+    main_pr = copy.deepcopy(PR_ROS_ROSDISTRO)
+    rolling_pr.base_ref = "rolling"
+    main_pr.base_ref = "main"
+
+    assert f(ISSUE_ROS_ROSDISTRO)
+    assert fnot(ISSUE_ROS_ROSDISTRO)
+    assert f(rolling_pr)
+    assert not fnot(rolling_pr)
+    assert not f(main_pr)
+    assert fnot(main_pr)
 
 
 def test_invert_require_draft_if_pr():


### PR DESCRIPTION
Fixes #49 

`base:r` filters PRs to show only PRs targeting a branch whose name begins with `r`

https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-branch-name